### PR TITLE
Project should build after fetching, this part prevented success.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": "my-user-script",
   "version": "0.0.0",
   "description": "*",
-  "main": "*",
+  "main": "index.js",
   "header": {
     "namespace": "*",
     "match": "*",


### PR DESCRIPTION
Otherwise you get:

```
> my-user-script@0.0.0 build D:\web\userscripts\webpack-tampermonkey\src
> webpack

Hash: a9ea42ccc2f847fccf0d
Version: webpack 3.10.0
Time: 31ms

ERROR in Entry module not found: Error: Can't resolve 'D:\web\userscripts\webpack-tampermonkey\src\*' in 'D:\web\userscripts\webpack-tampermonkey\src'
```